### PR TITLE
Allow tag to contain multiple words

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ In the simplest case, just pass a list of tags to render and actions for adding 
 - Whether or not it takes two presses of the backspace key to remove a tag. When enabled, the first backspace press will add the class `emberTagInput-tag--remove` to the element that is about to be removed.
 - **default: true**
 
-### allowMultipleWords
-- If multiple words are allowed in a tag
+### allowSpacesInTags
+- If tags are allowed to contain spaces.
 - **default: false**
 
 ### allowDuplicates

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ In the simplest case, just pass a list of tags to render and actions for adding 
 - Whether or not it takes two presses of the backspace key to remove a tag. When enabled, the first backspace press will add the class `emberTagInput-tag--remove` to the element that is about to be removed.
 - **default: true**
 
+### allowMultipleWords
+- If multiple words are allowed in a tag
+- **default: false**
+
 ### allowDuplicates
 - If duplicates tags are allowed in the list.
 - **default: false**

--- a/addon/components/tag-input.js
+++ b/addon/components/tag-input.js
@@ -24,6 +24,8 @@ export default Ember.Component.extend({
 
   allowDuplicates: false,
 
+  allowMultipleWords: false,
+
   showRemoveButtons: true,
 
   placeholder: '',
@@ -49,9 +51,9 @@ export default Ember.Component.extend({
     });
 
     newTagInput.on('keydown', (e) => {
+      const allowMultipleWords =  this.get('allowMultipleWords');
       const tags = this.get('tags');
       const newTag = newTagInput.val().trim();
-
       if (e.which === KEY_CODES.BACKSPACE) {
         if (newTag.length === 0 && tags.length > 0) {
           const removeTagAtIndex = this.get('removeTagAtIndex');
@@ -68,7 +70,7 @@ export default Ember.Component.extend({
           removeTagAtIndex(tags.length - 1);
         }
       } else {
-        if (e.which === KEY_CODES.COMMA || e.which === KEY_CODES.SPACE || e.which === KEY_CODES.ENTER) {
+        if (e.which === KEY_CODES.COMMA || (!allowMultipleWords && e.which === KEY_CODES.SPACE) || e.which === KEY_CODES.ENTER) {
           if (newTag.length > 0) {
             if (this.addNewTag(newTag)) {
               newTagInput.val('');

--- a/addon/components/tag-input.js
+++ b/addon/components/tag-input.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
 
   allowDuplicates: false,
 
-  allowMultipleWords: false,
+  allowSpacesInTags: false,
 
   showRemoveButtons: true,
 
@@ -51,9 +51,10 @@ export default Ember.Component.extend({
     });
 
     newTagInput.on('keydown', (e) => {
-      const allowMultipleWords =  this.get('allowMultipleWords');
+      const allowSpacesInTags = this.get('allowSpacesInTags');
       const tags = this.get('tags');
       const newTag = newTagInput.val().trim();
+
       if (e.which === KEY_CODES.BACKSPACE) {
         if (newTag.length === 0 && tags.length > 0) {
           const removeTagAtIndex = this.get('removeTagAtIndex');
@@ -70,7 +71,7 @@ export default Ember.Component.extend({
           removeTagAtIndex(tags.length - 1);
         }
       } else {
-        if (e.which === KEY_CODES.COMMA || (!allowMultipleWords && e.which === KEY_CODES.SPACE) || e.which === KEY_CODES.ENTER) {
+        if (e.which === KEY_CODES.COMMA || (!allowSpacesInTags && e.which === KEY_CODES.SPACE) || e.which === KEY_CODES.ENTER) {
           if (newTag.length > 0) {
             if (this.addNewTag(newTag)) {
               newTagInput.val('');

--- a/tests/integration/components/tag-input-test.js
+++ b/tests/integration/components/tag-input-test.js
@@ -123,10 +123,10 @@ test('Tags can be removed using the backspace key', function(assert) {
   });
 });
 
-test('Tags can contain multiple words when allowMultipleWords is set to true', function(assert) {
+test('Tags can contain spaces when allowSpacesInTags is set to true', function(assert) {
   assert.expect(3);
 
-  const tags = [];
+  const tags = Ember.A();
 
   this.addTag = function(tag) {
     tags.pushObject(tag);
@@ -137,7 +137,7 @@ test('Tags can contain multiple words when allowMultipleWords is set to true', f
     {{tag-input
       tags=tags
       addTag=(action addTag)
-      allowMultipleWords=true
+      allowSpacesInTags=true
     }}
   `);
 

--- a/tests/integration/components/tag-input-test.js
+++ b/tests/integration/components/tag-input-test.js
@@ -122,3 +122,37 @@ test('Tags can be removed using the backspace key', function(assert) {
     });
   });
 });
+
+test('Tags can contain multiple words when allowMultipleWords is set to true', function(assert) {
+  assert.expect(3);
+
+  const tags = [];
+
+  this.addTag = function(tag) {
+    tags.pushObject(tag);
+  };
+  this.set('tags', tags);
+
+  this.render(hbs`
+    {{tag-input
+      tags=tags
+      addTag=(action addTag)
+      allowMultipleWords=true
+    }}
+  `);
+
+  const done = assert.async();
+
+  Ember.run(() => {
+    typeInInput('.js-ember-tag-input-new', 'multiple words rock');
+
+    $('.js-ember-tag-input-new').blur();
+
+    Ember.run.next(() => {
+      assert.equal($('.js-ember-tag-input-new').text(), '');
+      assert.equal($('.emberTagInput-tag').length, 1);
+      assert.equal($('.emberTagInput-tag').eq(0).text().trim(), 'multiple words rock');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Tags currently don't allow multiple words. If you hit the space bar, a new tag is created automatically.

This PR creates the option: `allowMultipleWords` where when set to `true` it will allow you hit the space bar without creating a new tab

```
{{tag-input
  tags=tags
  placeholder='Add a tag...'
  addTag=(action 'addTag')
  allowMultipleWords=true
  removeTagAtIndex=(action 'removeTag')
}}
```

![screen shot 2017-05-26 at 5 51 30 pm](https://cloud.githubusercontent.com/assets/4490013/26513864/f919ea96-423b-11e7-8c11-604b6d5506d9.png)
