### PR TITLE
Add disableEnter option to disable adding a new tag with enter key stroke

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ The above example works if your tags array is just an simple array of strings. I
 - If a read only view of the tags should be displayed. If enabled, existing tags can't be removed and new tags can't be added.
 - **default: false**
 
+### disableEnter
+- disable enter key stroke to add new tag
+- **default: false**
+
 ## Actions
 
 ### addTag

--- a/addon/components/tag-input.js
+++ b/addon/components/tag-input.js
@@ -40,6 +40,8 @@ export default Component.extend({
 
   onKeyUp: false,
 
+  disableEnter: false,
+
   addNewTag(tag) {
     const tags = this.get('tags');
     const addTag = this.get('addTag');
@@ -64,6 +66,7 @@ export default Component.extend({
       const allowSpacesInTags = this.get('allowSpacesInTags');
       const tags = this.get('tags');
       const newTag = newTagInput.val().trim();
+      const disableEnter = this.get('disableEnter');
 
       if (e.which === KEY_CODES.BACKSPACE) {
         if (newTag.length === 0 && tags.length > 0) {
@@ -81,7 +84,7 @@ export default Component.extend({
           removeTagAtIndex(tags.length - 1);
         }
       } else {
-        if (e.which === KEY_CODES.COMMA || (!allowSpacesInTags && e.which === KEY_CODES.SPACE) || e.which === KEY_CODES.ENTER) {
+        if (e.which === KEY_CODES.COMMA || (!allowSpacesInTags && e.which === KEY_CODES.SPACE) || (!disableEnter && e.which === KEY_CODES.ENTER)) {
           if (newTag.length > 0) {
             if (this.addNewTag(newTag)) {
               newTagInput.val('');

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   tags: ['foo', 'bar'],
+  disableEnter: false,
 
   actions: {
     addTag(tag) {

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -4,10 +4,13 @@
   addTag=(action 'addTag')
   removeTagAtIndex=(action 'removeTag')
   onKeyUp=(action 'onKeyUp')
+  disableEnter=disableEnter
   as |tag|
 }}
   {{tag}}
 {{/tag-input}}
+
+{{input type="checkbox" checked=disableEnter}} Disable Enter
 
 {{#if currentInputValue}}
   <p>typing: {{currentInputValue}}</p>

--- a/tests/integration/components/tag-input-test.js
+++ b/tests/integration/components/tag-input-test.js
@@ -8,7 +8,8 @@ moduleForComponent('tag-input', 'Integration | Component | Ember Tag Input', {
 });
 
 const KEY_CODES = {
-  BACKSPACE: 8
+  BACKSPACE: 8,
+  ENTER: 13
 };
 
 test('New tags are created when delimiter characters are typed', function(assert) {
@@ -231,6 +232,40 @@ test('send input value when typing', function(assert) {
       assert.equal($('.emberTagInput-tag').length, 1);
       assert.equal($('.emberTagInput-tag').eq(0).text().trim(), 'tes');
       assert.equal(inputValue, '');
+      done();
+    });
+  });
+});
+
+test('disable enter key stroke to add new tag', function(assert) {
+  const tags = Ember.A();
+
+  this.addTag = function(tag) {
+    tags.pushObject(tag);
+  };
+
+  this.set('tags', tags);
+
+  this.render(hbs`
+    {{#tag-input
+      tags=tags
+      addTag=(action addTag)
+      disableEnter=true
+      as |tag|
+    }}
+      {{tag}}
+    {{/tag-input}}
+  `);
+
+  const done = assert.async();
+
+  Ember.run(() => {
+    typeInInput('.js-ember-tag-input-new', 'newTagWontBeAdded');
+    typeCharacterInInput('.js-ember-tag-input-new', String.fromCharCode(KEY_CODES.ENTER));
+
+    Ember.run.next(() => {
+      assert.equal($('.js-ember-tag-input-new').val(), 'newTagWontBeAdded');
+      assert.equal($('.emberTagInput-tag').length, 0);
       done();
     });
   });


### PR DESCRIPTION
I have a dropdown which i filter dynamically based on ember-tag-input value. When the user select one of the item from dropdown via pressing enter, text (which is incomplete and used for filtering) and the selected item from dropdown added as tags because both actions listening enter key press. So, I should have an ability to disable enter listener dynamically to prevent bad behaviour.

Intention
![screen shot 2017-08-16 at 15 44 09](https://user-images.githubusercontent.com/281380/29363744-c8ec8f1a-8299-11e7-8a73-15c5fc452dfa.png)

This is what happened without disable option
![screen shot 2017-08-16 at 15 42 34](https://user-images.githubusercontent.com/281380/29363682-9aa3fce2-8299-11e7-9bec-342a64b99e4d.png)
