### PR TITLE
Add aria-label attribute to input control

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ The above example works if your tags array is just an simple array of strings. I
 - The placeholder text to display when the user hasn't typed anything. Isn't displayed if readOnly=true.
 - **default: ''**
 
+### ariaLabel
+- The aria-label for the input field.
+- **default: ''**
+
 ### readOnly
 - If a read only view of the tags should be displayed. If enabled, existing tags can't be removed and new tags can't be added.
 - **default: false**

--- a/addon/components/tag-input.js
+++ b/addon/components/tag-input.js
@@ -34,6 +34,7 @@ export default Component.extend({
 
   placeholder: '',
 
+  ariaLabel: '',
   _isRemoveButtonVisible: computed('showRemoveButtons', 'readOnly', function() {
     return this.get('showRemoveButtons') && !this.get('readOnly');
   }),

--- a/addon/templates/components/tag-input.hbs
+++ b/addon/templates/components/tag-input.hbs
@@ -8,8 +8,8 @@
 {{~/each~}}
 
 <li class="emberTagInput-new">
-  <Input
-    @disabled={{this.readOnly}}
+  <input
+    disabled={{this.readOnly}}
     class={{concat 'emberTagInput-input js-ember-tag-input-new' (if readOnly ' is-disabled')}}
     maxlength={{this.maxlength}}
     placeholder={{this.placeholder}}

--- a/addon/templates/components/tag-input.hbs
+++ b/addon/templates/components/tag-input.hbs
@@ -8,10 +8,11 @@
 {{~/each~}}
 
 <li class="emberTagInput-new">
-  {{input
-    disabled=readOnly
-    class=(concat 'emberTagInput-input js-ember-tag-input-new' (if readOnly ' is-disabled'))
-    maxlength=maxlength
-    placeholder=placeholder
-  }}
+  <Input
+    @disabled={{this.readOnly}}
+    class={{concat 'emberTagInput-input js-ember-tag-input-new' (if readOnly ' is-disabled')}}
+    maxlength={{this.maxlength}}
+    placeholder={{this.placeholder}}
+    aria-label={{this.ariaLabel}}
+  />
 </li>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -3,6 +3,7 @@
 {{#tag-input
   tags=tags
   placeholder='Add a tag...'
+  ariaLabel='Add a tag input field'
   addTag=(action 'addTag')
   removeTagAtIndex=(action 'removeTag')
   onKeyUp=(action 'onKeyUp')
@@ -20,6 +21,7 @@
 {{#tag-input
   tags=tags
   placeholder='Add a tag...'
+  ariaLabel='Add a tag input field'
   addTag=(action 'addTag')
   removeTagAtIndex=(action 'removeTag')
   onKeyUp=(action 'onKeyUp')


### PR DESCRIPTION
### Purpose

Add the ability to specify an aria-label that will be attached to the text input field. This will fix https://github.com/calvinlough/ember-tag-input/issues/15

### Changes
1. Use HTML input field for the text input field instead of ember input helper
2. Add ariaLabel parameter to the tag-input
3. Use the ariaLabel parameter in the text input field
4. Update README
5. Update dummy app