### PR TITLE
Adds support to allow comma in tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The above example works if your tags array is just an simple array of strings. I
 - Whether or not it takes two presses of the backspace key to remove a tag. When enabled, the first backspace press will add the class `emberTagInput-tag--remove` to the element that is about to be removed.
 - **default: true**
 
+### allowCommaInTags
+- If tags are allowed to contain comma.
+- **default: false**
+
 ### allowSpacesInTags
 - If tags are allowed to contain spaces.
 - **default: false**

--- a/addon/components/tag-input.js
+++ b/addon/components/tag-input.js
@@ -21,6 +21,8 @@ export default class TagInput extends Component {
 
   removeConfirmation = true;
 
+  allowCommaInTags = false;
+
   allowDuplicates = false;
 
   allowSpacesInTags = false;
@@ -75,8 +77,7 @@ export default class TagInput extends Component {
 
   _onInputKeyDown(e) {
     if (!this.readOnly) {
-      const allowSpacesInTags = this.allowSpacesInTags;
-      const tags = this.tags;
+      const { allowCommaInTags, allowSpacesInTags, tags } = this;
       const backspaceRegex = new RegExp(
         String.fromCharCode(KEY_CODES.BACKSPACE),
         'g'
@@ -104,7 +105,7 @@ export default class TagInput extends Component {
         }
       } else {
         if (
-          e.which === KEY_CODES.COMMA ||
+          (!allowCommaInTags && e.which === KEY_CODES.COMMA) ||
           (!allowSpacesInTags && e.which === KEY_CODES.SPACE) ||
           e.which === KEY_CODES.ENTER
         ) {

--- a/tests/integration/components/tag-input-test.js
+++ b/tests/integration/components/tag-input-test.js
@@ -17,6 +17,7 @@ module(
     setupRenderingTest(hooks);
 
     const KEY_CODES = {
+      COMMA: 188,
       BACKSPACE: 8
     };
 
@@ -163,6 +164,75 @@ module(
       assert.equal(
         findAll('.emberTagInput-tag')[0].textContent.trim(),
         'multiple words rock'
+      );
+    });
+
+    test('Tags should not contain comma by default when allowCommaInTags is not provided', async function (assert) {
+      assert.expect(3);
+
+      const tags = A();
+
+      this.addTag = function (tag) {
+        tags.pushObject(tag);
+      };
+      this.set('tags', tags);
+
+      await render(hbs`
+        <TagInput
+          @tags={{this.tags}}
+          @addTag={{this.addTag}}
+          @allowCommaInTags={{false}}
+          as |tag|
+        >
+          {{tag}}
+        </TagInput>
+      `);
+
+      await typeIn('.js-ember-tag-input-new', 'Scrabble');
+      await triggerKeyEvent(
+        '.js-ember-tag-input-new',
+        'keydown',
+        KEY_CODES.COMMA
+      );
+
+      assert.dom('.js-ember-tag-input-new').includesText('');
+      assert.dom('.emberTagInput-tag').exists({ count: 1 });
+      assert.equal(
+        findAll('.emberTagInput-tag')[0].textContent.trim(),
+        'Scrabble'
+      );
+    });
+
+    test('Tags can contain commas when allowCommaInTags is set to true', async function (assert) {
+      assert.expect(3);
+
+      const tags = A();
+
+      this.addTag = function (tag) {
+        tags.pushObject(tag);
+      };
+      this.set('tags', tags);
+
+      await render(hbs`
+        <TagInput
+          @tags={{this.tags}}
+          @addTag={{this.addTag}}
+          @allowCommaInTags={{true}}
+          @allowSpacesInTags={{true}}
+          as |tag|
+        >
+          {{tag}}
+        </TagInput>
+      `);
+
+      await typeIn('.js-ember-tag-input-new', 'Scrabble, Words With Friends,');
+      await blur('.js-ember-tag-input-new');
+
+      assert.dom('.js-ember-tag-input-new').includesText('');
+      assert.dom('.emberTagInput-tag').exists({ count: 1 });
+      assert.equal(
+        findAll('.emberTagInput-tag')[0].textContent.trim(),
+        'Scrabble, Words With Friends,'
       );
     });
 


### PR DESCRIPTION
# Features

- Adding support to allow comma in tags, where in some case for some business requirements user can able to add `,` in the tags.
- Default behaviour is untouched as `allowCommaInTags` is false and logic activates only when user explicitly send true for `allowCommaInTags`.