### PR TITLE
Add a way to customize tags style

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ The above example works if your tags array is just an simple array of strings. I
   </div>
 </TagInput>
 ```
-
+If you pass tags objects, you can use the `modifiers` property to pass extra classes to individual tags:
+```
+tags = A([
+  { name: 'first', modifiers: 'primaryTag' },
+  { name: 'second', modifiers: 'secondaryTag' },
+]);
+```
 ## Options
 
 ### tags

--- a/addon/components/tag-input.hbs
+++ b/addon/components/tag-input.hbs
@@ -1,5 +1,5 @@
 {{#each this.tags as |tag index|~}}
-  <li class="emberTagInput-tag">
+  <li class="emberTagInput-tag {{tag.modifiers}}">
     {{yield tag}}
     {{#if this._isRemoveButtonVisible}}
       <a class="emberTagInput-remove" {{on 'click' (fn this.removeTag index)}}></a>

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -8,12 +8,26 @@ export default class IndexController extends Controller {
   @tracked readOnly = true;
   @tracked currentInputValue;
 
+  @tracked tagsObjects = [{ label: 'foo' }, { label: 'bar' }];
+  colors = ['green', 'red', 'purple'];
+
   @action addTag(tag) {
     this.tags.pushObject(tag);
   }
 
   @action removeTagAtIndex(index) {
     this.tags.removeAt(index);
+  }
+
+  @action addTagObject(tag) {
+    this.tagsObjects.pushObject({
+      label: tag,
+      modifiers: this.colors[Math.floor(Math.random() * 3)]
+    });
+  }
+
+  @action removeTagObjectAtIndex(index) {
+    this.tagsObjects.removeAt(index);
   }
 
   @action onKeyUp(value) {

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,9 @@
+.red {
+  background-color: rgb(161, 40, 40);
+}
+.green {
+  background-color: rgb(40, 161, 40);
+}
+.purple {
+  background-color: rgb(137, 74, 153);
+}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -36,3 +36,18 @@
 {{#if this.currentInputValue}}
   <p>typing: {{this.currentInputValue}}</p>
 {{/if}}
+
+<h1>Tags as objects</h1>
+<p>You can pass tags as strings or objects. If you pass objects, use the property `modifiers` to pass extra classes to tags.</p>
+
+<TagInput
+  @tags={{this.tagsObjects}}
+  @placeholder="Add a tag..."
+  @ariaLabel="Add a tag input field"
+  @addTag={{this.addTagObject}}
+  @removeTagAtIndex={{this.removeTagObjectAtIndex}}
+  @onKeyUp={{this.onKeyUp}}
+  as |tag|
+>
+  {{tag.label}}
+</TagInput>

--- a/tests/integration/components/tag-input-test.js
+++ b/tests/integration/components/tag-input-test.js
@@ -366,5 +366,34 @@ module(
 
       assert.dom('input').isDisabled();
     });
+
+    test('Tags as objects rely on property @modifiers to get custom classes', async function (assert) {
+      const tags = A([
+        {
+          label: 'hamburger',
+          modifiers: 'burger-style meat-style'
+        },
+        {
+          label: 'cheeseburger',
+          modifiers: 'burger-style cheese-style'
+        }
+      ]);
+
+      this.set('tags', tags);
+
+      await render(hbs`
+        <TagInput
+          @tags={{tags}}
+        as |tag|>
+          {{tag.label}}
+        </TagInput>
+      `);
+
+      let tagsElements = findAll('.emberTagInput-tag');
+      assert.ok(tagsElements[0].className.includes('burger-style meat-style'));
+      assert.ok(
+        tagsElements[1].className.includes('burger-style cheese-style')
+      );
+    });
   }
 );

--- a/tests/integration/components/tag-input-test.js
+++ b/tests/integration/components/tag-input-test.js
@@ -383,13 +383,14 @@ module(
 
       await render(hbs`
         <TagInput
-          @tags={{tags}}
-        as |tag|>
+          @tags={{this.tags}}
+          as |tag|
+        >
           {{tag.label}}
         </TagInput>
       `);
 
-      let tagsElements = findAll('.emberTagInput-tag');
+      const tagsElements = findAll('.emberTagInput-tag');
       assert.ok(tagsElements[0].className.includes('burger-style meat-style'));
       assert.ok(
         tagsElements[1].className.includes('burger-style cheese-style')


### PR DESCRIPTION
A rebase of BlueCutOfficials PR [here](https://github.com/calvinlough/ember-tag-input/pull/221)

Honors a `modifiers` property on individual tags and appends that property to the tag `li` element.